### PR TITLE
Set the correct alias for the Api class

### DIFF
--- a/src/FreshdeskServiceProvider.php
+++ b/src/FreshdeskServiceProvider.php
@@ -36,7 +36,7 @@ class FreshdeskServiceProvider extends ServiceProvider
             $config = $app->make('config')->get('freshdesk');
             return new Api($config['api_key'], $config['domain']);
         });
-        $this->app->alias('freshdesk', '\Mpclarkson\Laravel\Freshdesk\Api');
+        $this->app->alias('freshdesk', Api::class);
     }
 
     /**
@@ -46,6 +46,6 @@ class FreshdeskServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return ['freshdesk', '\Mpclarkson\Laravel\Freshdesk\Api'];
+        return ['freshdesk', Api::class];
     }
 }


### PR DESCRIPTION
The former `\Mpclarkson\...` didn't work since we're actually requesting `Mpclarkson\...`, so the leading `\` prevented correct resolution of the API class on dependency injection.